### PR TITLE
Output data in a format as required by check_mk

### DIFF
--- a/check_kernel_freshness
+++ b/check_kernel_freshness
@@ -73,29 +73,29 @@ $filename .= ' -> ' . readlink($filename) if ( -l $filename );
 if ($grub_kernelversion) {
     if ( $grub_kernelversion ne $running_version ) {
         print
-"WARNING: Version mismatch between running ($running_version) and GRUB default ($grub_kernelversion)\n";
+"1 check_kernel_freshness - WARNING: Version mismatch between running ($running_version) and GRUB default ($grub_kernelversion)\n";
         exit 1;
     }
 
     print
-"OK: Running Kernel ($running_version $running_build) matches GRUB default ($grub_kernelversion)\n";
+"0 check_kernel_freshness - OK: Running Kernel ($running_version $running_build) matches GRUB default ($grub_kernelversion)\n";
     exit 0;
 }
 
 if ( $running_version ne $image_version ) {
     print
-"WARNING: Version mismatch between running ($running_version) and installed $filename ($image_version) kernel\n";
+"1 check_kernel_freshness - WARNING: Version mismatch between running ($running_version) and installed $filename ($image_version) kernel\n";
     exit 1;
 }
 
 if ( $running_build ne $image_build ) {
     print
-"WARNING: Build mismatch between $image_version kernels. Running: $running_build, installed ($filename): $image_build\n";
+"1 check_kernel_freshness - WARNING: Build mismatch between $image_version kernels. Running: $running_build, installed ($filename): $image_build\n";
     exit 1;
 }
 
 print
-"OK: Running Kernel ($running_version $running_build) matches installed version ($filename)\n";
+"0 check_kernel_freshness - OK: Running Kernel ($running_version $running_build) matches installed version ($filename)\n";
 exit 0;
 
 ########


### PR DESCRIPTION
The data is expected in a format like:

  status | item_name | performance_data | check output

as specified on http://mathias-kettner.de/checkmk_localchecks.html
Note: we don't have performance data, that's why we use "-" to skip
the third column.

Using this script with check_mk is as simple as placing the file
inside /usr/lib/check_mk_agent/local/
